### PR TITLE
Fix for column names with special characters

### DIFF
--- a/tools/generate_sqlite_result/convert_tsv_to_sqlite.py
+++ b/tools/generate_sqlite_result/convert_tsv_to_sqlite.py
@@ -91,7 +91,7 @@ def get_parameters(parameter_file):
     if not os.path.isfile(parameter_file):
         return None, None, None, None
     # parse parameter file
-    configuration = configparser.ConfigParser(allow_no_value=True)
+    configuration = configparser.ConfigParser(allow_no_value=True, delimiters=('='))
     configuration.optionxform = str
     configuration.read(parameter_file)
     # extract relevant parameters


### PR DESCRIPTION
Fixed a bug in which TSV column names containing a colon (":") character would crash the converter, since the Python ConfigParser by default interprets this as a valid properties file key:value delimiter.