### PR TITLE
ConfigParser fix

### DIFF
--- a/tools/generate_sqlite_result/convert_tsv_to_sqlite.py
+++ b/tools/generate_sqlite_result/convert_tsv_to_sqlite.py
@@ -88,7 +88,7 @@ def get_parameters(parameter_file):
     if not os.path.isfile(parameter_file):
         return None, None, None, None
     # parse parameter file
-    configuration = configparser.ConfigParser(allow_no_value=True, delimiters=('='))
+    configuration = configparser.ConfigParser(allow_no_value=True, delimiters=('='), comment_prefixes=None)
     configuration.optionxform = str
     configuration.read(parameter_file)
     # extract relevant parameters


### PR DESCRIPTION
Fixed a bug in which column names starting with "#" were being ignored due to the ConfigParser's default behavior of treating lines starting with this character as comments.